### PR TITLE
console.log: Add information for updating the s5 from 2008 to 2034 in case "ERROR:Did not receive a firmware download request after 30s" is showing up

### DIFF
--- a/commands/aioinstall.js
+++ b/commands/aioinstall.js
@@ -186,6 +186,10 @@ module.exports = async (filePath) => {
         let downloadTimeout = setTimeout(() => {
             console.error("ERROR: Did not receive a firmware download request after 30s");
 
+            console.log("\nIf you are trying to upgrade the S5 from 2008 to 2034, you may have to install the 2034 manually with ssh.");
+            console.log("Checkout the following link for updating with ssh https://valetudo.cloud/pages/usage/upgrading.html");
+          
+
             console.log("\n\nExiting..");
 
             process.exit(-1);


### PR DESCRIPTION
Hi, this pull request would add two console log outputs to give other people a hint that an upgrade from 2008 to 2034 should possibly be done via ssh

I upgraded my Roborock s5 from "factory firmware" → 1886 → 2008 with this awesome tool.

After I tried to upgrade from 2008 to 2034 l always received the error: "_ERROR:Did not receive a firmware download request after 30s_", and after some research I found out, that some other people had the same error.
Maybe the 2008 Firmware is blocking the upgrades?

The people in the following forum (the forum is in German, if site translation is not working, or additional information are required, I can translate) are saying that they had the same problem and that it might be needed to install the 2034 manually with ssh. 
[roborock-s50-2nd-gen-laesst-sich-nicht-auf-das-neueste-dustbuilder-image-mit-fw-2034-updaten](https://www.roboter-forum.com/threads/roborock-s50-2nd-gen-laesst-sich-nicht-auf-das-neueste-dustbuilder-image-mit-fw-2034-updaten.59051/)

Maybe we can add this console log to the application, in order to give a hint to others.

BTW: This is my first contribution, if anything is missing, please reach out.