### PR TITLE
Add macos to build scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,18 @@
                     'asset_content_type': 'binary/octet-stream',
                   },
               },
+              {
+                'name': 'Upload macos',
+                'uses': 'actions/upload-release-asset@v1.0.2',
+                'env': { 'GITHUB_TOKEN': '${{ secrets.GITHUB_TOKEN }}' },
+                'with':
+                  {
+                    'upload_url': '${{ github.event.release.upload_url }}',
+                    'asset_path': './build/valetudo-helper-miioota-macos',
+                    'asset_name': 'valetudo-helper-miioota-macos',
+                    'asset_content_type': 'binary/octet-stream',
+                  },
+              },
             ],
         },
     },

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "lint": "eslint .",
     "lint_fix": "eslint . --fix",
 
-    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7",
+    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7 && npm run build_macos",
     "build_win": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-win-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota.exe",
     "build_lin_amd64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-amd64",
-    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-armv7"
-
+    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-armv7",
+    "build_macos": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-macos-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-macos"
+  
   },
   "pkg": {
     "assets": [


### PR DESCRIPTION
The Linux build does not work for MacOs. `exec format error` is thrown in zsh, building a binary for MacOs fixes this and helped successfully flashing my robots (tested on MacOs 13.1 non Apple Silicon). Not sure if you want the publishing part I just added it out of completeness