### PR TITLE
Feature: Add Mac binary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@
                 'with':
                   {
                     'upload_url': '${{ github.event.release.upload_url }}',
-                    'asset_path': './build/valetudo-helper-miioota-amd64',
-                    'asset_name': 'valetudo-helper-miioota-amd64',
+                    'asset_path': './build/valetudo-helper-miioota-lin-amd64',
+                    'asset_name': 'valetudo-helper-miioota-lin-amd64',
                     'asset_content_type': 'binary/octet-stream',
                   },
               },
@@ -52,8 +52,20 @@
                 'with':
                   {
                     'upload_url': '${{ github.event.release.upload_url }}',
-                    'asset_path': './build/valetudo-helper-miioota-armv7',
-                    'asset_name': 'valetudo-helper-miioota-armv7',
+                    'asset_path': './build/valetudo-helper-miioota-lin-armv7',
+                    'asset_name': 'valetudo-helper-miioota-lin-armv7',
+                    'asset_content_type': 'binary/octet-stream',
+                  },
+              },
+              {
+                'name': 'Upload mac arm64',
+                'uses': 'actions/upload-release-asset@v1.0.2',
+                'env': { 'GITHUB_TOKEN': '${{ secrets.GITHUB_TOKEN }}' },
+                'with':
+                  {
+                    'upload_url': '${{ github.event.release.upload_url }}',
+                    'asset_path': './build/valetudo-helper-miioota-mac-amd64',
+                    'asset_name': 'valetudo-helper-miioota-mac-amd64',
                     'asset_content_type': 'binary/octet-stream',
                   },
               },

--- a/package.json
+++ b/package.json
@@ -7,15 +7,13 @@
   "scripts": {
     "start": "node app.js",
     "install-firmware": "node app.js install-firmware v11_2034.pkg",
-
     "lint": "eslint .",
     "lint_fix": "eslint . --fix",
-
-    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7",
+    "build": "npm run build_win && npm run build_lin_amd64 && npm run build_lin_armv7 && npm run build_mac_arm64",
     "build_win": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-win-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota.exe",
-    "build_lin_amd64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-amd64",
-    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-armv7"
-
+    "build_lin_amd64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-x64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-lin-amd64",
+    "build_lin_armv7": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-linuxstatic-armv7 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-lin-armv7",
+    "build_mac_arm64": "cross-env PKG_CACHE_PATH=./build_dependencies/pkg pkg --targets node16-macos-arm64 --compress Brotli --no-bytecode --public-packages \"*\" . --output ./build/valetudo-helper-miioota-mac-amd64"
   },
   "pkg": {
     "assets": [
@@ -33,15 +31,15 @@
     "semaphore": "^1.1.0"
   },
   "devDependencies": {
-    "cross-env": "7.0.3",
-    "pkg": "5.6.0",
+    "cross-env": "^7.0.3",
     "eslint": "7.32.0",
-    "eslint-plugin-react": "7.27.1",
-    "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-jsdoc": "37.0.3",
     "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-react": "7.27.1",
+    "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-regexp": "1.5.1",
     "eslint-plugin-sort-keys-fix": "^1.1.1",
-    "eslint-plugin-sort-requires": "git+https://npm@github.com/Hypfer/eslint-plugin-sort-requires.git#2.1.1"
+    "eslint-plugin-sort-requires": "git+https://npm@github.com/Hypfer/eslint-plugin-sort-requires.git#2.1.1",
+    "pkg": "5.6.0"
   }
 }


### PR DESCRIPTION
1. Revised the `package.json` to include a build script targetting Apple Silicon Mac platforms.
2. Included that build script in the `npm run build` runner
3. Revised the Github Workflow to also publish the Mac-targetting binary.